### PR TITLE
Configure BMI270 I2C address to 0x69

### DIFF
--- a/src/sensors/softfusion/drivers/bmi270.h
+++ b/src/sensors/softfusion/drivers/bmi270.h
@@ -41,7 +41,7 @@ namespace SlimeVR::Sensors::SoftFusion::Drivers {
 // Timestamps reading are not used
 
 struct BMI270 {
-	static constexpr uint8_t Address = 0x68;
+	static constexpr uint8_t Address = 0x69;
 	static constexpr auto Name = "BMI270";
 	static constexpr auto Type = SensorTypeID::BMI270;
 


### PR DESCRIPTION
This change modifies the BMI270 sensor driver to use I2C address 0x69 instead of the default 0x68.